### PR TITLE
Add missing application tuple value for elli dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang; flycheck-mode: nil -*-
 {erl_opts, [debug_info]}.
-{deps, [{erlando, "3.1.1"}, {elli, "3.1.0"}]}.
+{deps, [{erlando, "3.1.1"}]}.
 {project_plugins,
  [{coveralls, "1.4.0"},
   {rebar3_lint, "0.1.9"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang; flycheck-mode: nil -*-
 {erl_opts, [debug_info]}.
-{deps, [{erlando, "3.1.1"}]}.
+{deps, [{erlando, "3.1.1"}, {elli, "3.1.0"}]}.
 {project_plugins,
  [{coveralls, "1.4.0"},
   {rebar3_lint, "0.1.9"}]}.
@@ -12,7 +12,7 @@
 {profiles,
  [{test,
    [{deps,
-     [{elli, "3.0.0"}]},
+     [{elli, "3.1.0"}]},
     {dialyzer,
      [{plt_extra_apps, [elli]}]}
    ]},

--- a/src/elli_cache.app.src
+++ b/src/elli_cache.app.src
@@ -2,7 +2,7 @@
  [{description, "Elli middleware for generic caching."},
   {vsn, "1.0.1"},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, elli]},
   {modules, []},
 
   {maintainers, ["Eric Bailey"]},


### PR DESCRIPTION
It is possible that rebar incorrectly assumes the order of the dependencies necessary to compile. This will manifest itself in an error that resembels:

```
===> Compiling _build/default/lib/elli_cache/src/elli_middleware_cache.erl failed
_build/default/lib/elli_cache/src/elli_middleware_cache.erl:19: can't find include lib "elli/include/elli.hrl"
...
```

This is recognized in [this post](https://www.rebar3.org/discuss/594ac60e9eae99002eca669b), where Fred Hobert explains that if a dependency isn't listed as a dependency in the application tuple, rebar3 does not guarantee the build order.

This change fixes this issue for rebar3.